### PR TITLE
Override the models the prune command looks for

### DIFF
--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -4,18 +4,22 @@ namespace Maize\PrunableFields\Support;
 
 class Config
 {
-    protected static \Closure $callback;
+    /**
+     * @var callable|null
+     */
+    protected static $callback;
 
-    public static function resolvePrunableModelsUsing(\Closure $callback)
+    public static function resolvePrunableModelsUsing(?callable $callback): void
     {
         static::$callback = $callback;
     }
 
     public static function getPrunableModels(): array
     {
-        if(isset(static::$callback)) {
+        if (is_callable(static::$callback)) {
             return call_user_func(static::$callback);
         }
+
         return config('prunable-fields.models', []);
     }
 }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -4,8 +4,18 @@ namespace Maize\PrunableFields\Support;
 
 class Config
 {
+    protected static \Closure $callback;
+
+    public static function resolvePrunableModelsUsing(\Closure $callback)
+    {
+        static::$callback = $callback;
+    }
+
     public static function getPrunableModels(): array
     {
+        if(isset(static::$callback)) {
+            return call_user_func(static::$callback);
+        }
         return config('prunable-fields.models', []);
     }
 }

--- a/tests/MassPrunableFieldsTest.php
+++ b/tests/MassPrunableFieldsTest.php
@@ -56,17 +56,3 @@ test('should fire ModelsFieldsPruned event with mass prunable model', function (
         fn (ModelsFieldsPruned $e) => $e->count === 1 && $e->model === MassPrunableUser::class
     );
 })->with('user_with_mass_prunable_fields');
-
-test('should allow the prunable models to be overridden at runtime', function(MassPrunableUser $model) {
-    \Maize\PrunableFields\Support\Config::resolvePrunableModelsUsing(fn() => [MassPrunableUser::class]);
-    
-    Event::fake();
-
-    pruneFields([]);
-
-    Event::assertDispatched(
-        ModelsFieldsPruned::class,
-        fn (ModelsFieldsPruned $e) => $e->count === 1 && $e->model === MassPrunableUser::class
-    );
-
-})->with('user_with_mass_prunable_fields');

--- a/tests/MassPrunableFieldsTest.php
+++ b/tests/MassPrunableFieldsTest.php
@@ -56,3 +56,17 @@ test('should fire ModelsFieldsPruned event with mass prunable model', function (
         fn (ModelsFieldsPruned $e) => $e->count === 1 && $e->model === MassPrunableUser::class
     );
 })->with('user_with_mass_prunable_fields');
+
+test('should allow the prunable models to be overridden at runtime', function(MassPrunableUser $model) {
+    \Maize\PrunableFields\Support\Config::resolvePrunableModelsUsing(fn() => [MassPrunableUser::class]);
+    
+    Event::fake();
+
+    pruneFields([]);
+
+    Event::assertDispatched(
+        ModelsFieldsPruned::class,
+        fn (ModelsFieldsPruned $e) => $e->count === 1 && $e->model === MassPrunableUser::class
+    );
+
+})->with('user_with_mass_prunable_fields');

--- a/tests/PrunableFieldsTest.php
+++ b/tests/PrunableFieldsTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Maize\PrunableFields\Events\ModelsFieldsPruned;
+use Maize\PrunableFields\Support\Config;
 use Maize\PrunableFields\Tests\Events\UserUpdatedEvent;
 use Maize\PrunableFields\Tests\Models\PrunableUser;
 
@@ -66,4 +67,19 @@ test('should fire ModelsFieldsPruned event with prunable model', function (Pruna
         ModelsFieldsPruned::class,
         fn (ModelsFieldsPruned $e) => $e->count === 1 && $e->model === PrunableUser::class
     );
+})->with('user_with_prunable_fields');
+
+test('should allow the prunable models to be overridden at runtime', function (PrunableUser $model) {
+    Config::resolvePrunableModelsUsing(fn () => [PrunableUser::class]);
+
+    Event::fake();
+
+    pruneFields([]);
+
+    Event::assertDispatched(
+        ModelsFieldsPruned::class,
+        fn (ModelsFieldsPruned $e) => $e->count === 1 && $e->model === PrunableUser::class
+    );
+
+    Config::resolvePrunableModelsUsing(null);
 })->with('user_with_prunable_fields');


### PR DESCRIPTION
We're wanting to use this package in a modular environment - most of our models are optional so we want to prune them if included but not if they aren't. I'd also like to define the models within the module rather than specifying them in config.

This PR lets you add an optional callback to override the config value. This will let us dynamically list the models to search for, without changing the default behaviour.